### PR TITLE
Fix link to TBB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,15 @@ if(GUI_APPLICATION AND PROJECT_MAIN_TYPE STREQUAL "qt" OR PROJECT_MAIN_TYPE STRE
         endif()
     endif()
 
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIB_MODULES} ${QT_MODULES_LINK} ${OS_LIBS})
+    # C++ STL Library Features Libs.
+    find_package(${LIB_STL_MODULES} REQUIRED COMPONENTS ${LIB_STL_MODULES_LINKER})
+
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+            ${LIB_STL_MODULES_LINKER}
+            ${LIB_MODULES}
+            ${QT_MODULES_LINK}
+            ${OS_LIBS}
+        )
 
     #Extra Modules
     target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/source PRIVATE source ${LIB_TARGET_INCLUDE_DIRECTORIES})

--- a/cmake/compiler-options.cmake
+++ b/cmake/compiler-options.cmake
@@ -35,6 +35,24 @@ if (OPTIMIZATION_LEVEL)
   add_definitions(-DOPTIMIZATION_LEVEL)
 endif()
 
+# C++ STL Library Features.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND LIB_STL_MODULES TBB)
+    list(APPEND LIB_STL_MODULES_LINKER tbb)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    #Todo...
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    #Todo...
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    #Todo...
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message("-- CMake run for msvc")
     if(OPTIMIZATION_LEVEL EQUAL "0")


### PR DESCRIPTION
link to TBB has been added for GNU compiler

fom [GNU](https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2020) site

> Note 3: The Parallel Algorithms have an external dependency on Intel TBB 2018 or later. If the \<execution\> header is included then -ltbb must be used to link to TBB.

Threading Building Blocks (TBB)